### PR TITLE
Sf 2.8+ deprecation warning removal

### DIFF
--- a/Router/I18nRouter.php
+++ b/Router/I18nRouter.php
@@ -129,8 +129,17 @@ class I18nRouter extends Router
             $this->context->setHost($this->hostMap[$locale]);
         }
 
+        // Deprecation warning removal for Sf 2.8+
+        if (false === $absolute) {
+            $referenceType = self::ABSOLUTE_PATH;
+        } elseif (true === $absolute) {
+            $referenceType = self::ABSOLUTE_URL;
+        } else {
+            $referenceType = $absolute;
+        }
+
         try {
-            $url = $generator->generate($locale.I18nLoader::ROUTING_PREFIX.$name, $parameters, $absolute);
+            $url = $generator->generate($locale.I18nLoader::ROUTING_PREFIX.$name, $parameters, $referenceType);
 
             if ($absolute && $this->hostMap) {
                 $this->context->setHost($currentHost);
@@ -146,7 +155,7 @@ class I18nRouter extends Router
         }
 
         // use the default behavior if no localized route exists
-        return $generator->generate($name, $parameters, $absolute);
+        return $generator->generate($name, $parameters, $referenceType);
     }
 
     /**


### PR DESCRIPTION
This removes the `The hardcoded value you are using for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate method is deprecated since version 2.8 and will not be supported anymore in 3.0. Use the constants defined in the UrlGeneratorInterface instead` warning from logs.
